### PR TITLE
Allowed to access the wire method by mixing in Macwire trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ trait UserModuleForTests extends UserModule {
 }
 ````
 
+Instead of importing the wire method in each module you can also extend com.softwaremill.macwire.Macwire trait.
+
 The library has no dependencies, and itself is not a runtime dependency. It only needs to be available on the classpath
 during compilation.
 

--- a/core/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
+++ b/core/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
@@ -4,9 +4,11 @@ import language.experimental.macros
 
 import reflect.macros.Context
 
-object MacwireMacros {
-  def wire[T]: T = macro wire_impl[T]
+trait Macwire {
+  def wire[T]: T = macro MacwireMacros.wire_impl[T]
+}
 
+object MacwireMacros extends Macwire {
   private val debug = new Debug()
   import Util._
 

--- a/tests/src/test/resources/simpleValsOkInTraitExtendingMacwire
+++ b/tests/src/test/resources/simpleValsOkInTraitExtendingMacwire
@@ -1,0 +1,11 @@
+#include commonSimpleClasses
+
+import com.softwaremill.macwire.Macwire
+
+trait Test extends Macwire {
+    val theA = wire[A]
+    val theB = wire[B]
+    val theC = wire[C]
+}
+
+#include commonSimpleNotNullCheck

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -30,7 +30,12 @@ class CompileTests extends FlatSpec with ShouldMatchers {
     ("inheritanceClassesWithTraitsLazyValsOkInTraits", Nil)
   )
 
-  for ((testName, expectedErrors) <- tests) {
+  for ((testName, expectedErrors) <- tests)
+    addTest(testName, expectedErrors)
+
+  addTest("simpleValsOkInTraitExtendingMacwire", Nil, "/* Note no additional import needed */")
+
+  def addTest(testName: String, expectedErrors: List[String], imports: String = GlobalImports) {
     it should s"$testName should ${if (expectedErrors == Nil) "compile & run" else "cause a compile error"}" in {
       import scala.reflect.runtime._
       val cm = universe.runtimeMirror(getClass.getClassLoader)
@@ -38,7 +43,7 @@ class CompileTests extends FlatSpec with ShouldMatchers {
       import scala.tools.reflect.ToolBox
       val tb = cm.mkToolBox()
 
-      val source = loadTest(testName)
+      val source = loadTest(testName, imports)
 
       try {
         tb.eval(tb.parse(source))
@@ -57,7 +62,7 @@ class CompileTests extends FlatSpec with ShouldMatchers {
     }
   }
 
-  def loadTest(name: String) = GlobalImports + resolveDirectives(loadResource(name)) + EmptyResult
+  def loadTest(name: String, imports: String) = imports + resolveDirectives(loadResource(name)) + EmptyResult
 
   def loadResource(name: String) = {
     val resource = this.getClass.getResourceAsStream("/" + name)


### PR DESCRIPTION
When building modules extending each other you need to repeat the import of MacwireMacros.wire method in each module. The only way to avoid it is to:
1) either keep all modules in one compilation unit, or
2) assign MacwireMacros to some val (like val injector = MacwireMacros) and then call injector.wire in all subtraits
Both those solutions have their drawbacks.

The proposed change allows to mix in Macwire trait (where the wire method is defined) in order to have that method directly accessible in subtraits.
