### PR TITLE
Ignore Nothing/Null when looking for dependencies

### DIFF
--- a/core/src/main/scala/com/softwaremill/macwire/ValuesOfTypeInEnclosingClassFinder.scala
+++ b/core/src/main/scala/com/softwaremill/macwire/ValuesOfTypeInEnclosingClassFinder.scala
@@ -49,7 +49,7 @@ private[macwire] class ValuesOfTypeInEnclosingClassFinder[C <: Context](val c: C
           }
         }
 
-        if (rhsTpe <:< t) {
+        if (rhsTpe <:< t !(rhsTpe =:= typeOf[Nothing]) && !(rhsTpe =:= typeOf[Null])) {
           debug(s"Found a match in enclosing class/trait!")
           name.encodedName :: acc
         } else {

--- a/core/src/main/scala/com/softwaremill/macwire/ValuesOfTypeInParentsFinder.scala
+++ b/core/src/main/scala/com/softwaremill/macwire/ValuesOfTypeInParentsFinder.scala
@@ -20,7 +20,7 @@ private[macwire] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug
         case _ => Nil
       })
 
-      typesToCheck.exists(_ <:< t)
+      typesToCheck.exists(ty => <:< t && !(ty =:= typeOf[Nothing]) && !(ty =:= typeOf[Null]))
     }
 
     def findInParent(parent: Tree): Set[Name] = {


### PR DESCRIPTION
When looking for a value of a certain type in the eclosing and the
parent class, values of type Nothing or Null should be ignored.

For example, ScalaTest 2.0 defines the nullary methods cancel and fail
of type Nothing, which prevent using a mixed in MacWire module in a
test because they match any type.
