### PR TITLE
Wire implicit dependencies (issue #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ type in the enclosing method and trait/class/object:
 * first it tries to find a value declared in the enclosing method; if multiple values are found, a by name-match is attempted
 * then it tries to find a unique value declared in the enclosing type
 * then it tries to find a unique value in parent types (traits/classes)
+* then, if the parameter is marked as an implicit, it returns value inferred from an implicit scope
 
 Here value means either a `val` or a no-parameter `def`, as long as the return type matches.
 
 A compile-time error occurs if:
 
 * there are multiple values of a given type declared in the enclosing type, or in parent types
+* parameter is marked as implicit and there are at least one matching value declared in both enclosure/parents and implicit scopes.
 * there is no value of a given type
 
 The generated code is then once again type-checked by the Scala compiler.

--- a/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/DependencyResolver.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/DependencyResolver.scala
@@ -1,0 +1,62 @@
+package com.softwaremill.macwire.dependencyLookup
+
+import com.softwaremill.macwire.Debug
+import com.softwaremill.macwire.Util._
+
+import scala.reflect.macros.blackbox
+
+private[macwire] class DependencyResolver[C <: blackbox.Context](val c: C, debug: Debug) {
+
+  import c.universe._
+
+  private lazy val implicitValuesFinder = new ImplicitValueOfTypeFinder[c.type](c, debug)
+
+  private lazy val enclosingMethodParamsFinder = new ValuesOfTypeInEnclosingMethodFinder[c.type](c, debug);
+
+  private lazy val enclosingClassFinder = new ValuesOfTypeInEnclosingClassFinder[c.type](c, debug)
+
+  private lazy val parentsMembersFinder = new ValuesOfTypeInParentsFinder[c.type](c, debug)
+
+  def resolve(param: Symbol, t: Type): Option[c.Tree] = {
+
+    debug.withBlock(s"Trying to find value [${param.name}] of type: [$t]") {
+
+      val results: List[Tree] = enclosingMethodParamsFinder.find(param, t) match {
+        case Nil =>
+          val implicitInferenceResults =
+            if (param.isImplicit) implicitValuesFinder.find(t)
+            else None
+
+          /* First, we perform plain, old, regular value lookup that will exclude found
+           * implicit value if need */
+          val regularLookupValues = firstNotEmpty[Tree](
+            () => enclosingClassFinder.find(t, implicitInferenceResults),
+            () => parentsMembersFinder.find(t, implicitInferenceResults)
+          ).getOrElse(Nil)
+          /* After regular lookup, we combine both results together.
+           *
+           * It's done as an separate step to prevent macro from resolving dependency too early
+           * and thus shadowing non ambiguous resolution problems when:
+           * 1) constructor parameter is marked as an implicit and
+           * 2) there is no matching value in appropriate scope, but
+           * 3) implicit value is present in some outer scope (parent, package/companion object,
+           * explicit imports and so on).
+           */
+          implicitInferenceResults.map(_ :: regularLookupValues).getOrElse(regularLookupValues)
+        case values => values
+      }
+
+      results match {
+        case Nil =>
+          c.error(c.enclosingPosition, s"Cannot find a value of type: [$t]")
+          None
+        case value :: Nil =>
+          debug(s"Found single value: [$value] of type [$t]")
+          Some(value)
+        case values =>
+          c.error(c.enclosingPosition, s"Found multiple values of type [$t]: [$values]")
+          None
+      }
+    }
+  }
+}

--- a/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ImplicitValueOfTypeFinder.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ImplicitValueOfTypeFinder.scala
@@ -1,0 +1,23 @@
+package com.softwaremill.macwire.dependencyLookup
+
+import com.softwaremill.macwire.Debug
+
+import scala.reflect.macros.blackbox.Context
+
+private[dependencyLookup] class ImplicitValueOfTypeFinder[C <: Context](val c: C, debug: Debug) {
+  import c.universe._
+
+  def find(t: Type): Option[c.Tree] = {
+    debug.withBlock("Looking for implicit value") {
+      c.inferImplicitValue(t, true, false, c.enclosingPosition) match {
+        case EmptyTree =>
+          debug("There is no implicit values in scope")
+          None
+        case tree => {
+          debug("Found matching implicit value")
+          Some(tree)
+        }
+      }
+    }
+  }
+}

--- a/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ValuesOfTypeInParentsFinder.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ValuesOfTypeInParentsFinder.scala
@@ -1,14 +1,16 @@
-package com.softwaremill.macwire
+package com.softwaremill.macwire.dependencyLookup
 
-import reflect.macros.blackbox.Context
-import annotation.tailrec
+import com.softwaremill.macwire.{Debug, TypeCheckUtil}
 
-private[macwire] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug: Debug) {
+import scala.annotation.tailrec
+import scala.reflect.macros.blackbox.Context
+
+private[dependencyLookup] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug: Debug) {
   import c.universe._
 
   private val typeCheckUtil = new TypeCheckUtil[c.type](c, debug)
 
-  def find(t: Type): List[Name] = {
+  def find(t: Type, implicitValue: Option[Tree]): List[Tree] = {
     def checkCandidate(tpt: Type): Boolean = {
       val typesToCheck = tpt :: (tpt match {
         case NullaryMethodType(resultType) => List(resultType)
@@ -19,7 +21,7 @@ private[macwire] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug
       typesToCheck.exists(ty => ty <:< t && typeCheckUtil.candidateTypeOk(ty))
     }
 
-    def findInParent(parent: Tree): Set[Name] = {
+    def findInParent(parent: Tree): List[Tree] = {
       debug.withBlock(s"Checking parent: [${parent.tpe}]") {
         val parentType = if (parent.tpe == null) {
           debug("Parent type is null. Creating an expression of parent's type and type-checking that expression ...")
@@ -38,24 +40,24 @@ private[macwire] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug
         } else {
           parent.tpe
         }
-
-        val result = parentType.members
-          .filter(symbol => checkCandidate(symbol.typeSignature))
-          .map(_.name)
-          // For (lazy) vals, the names have a space at the end of the name (probably some compiler internals).
-          // Hence the trim.
-          .map(name => TermName(name.decodedName.toString.trim()))
-
-        if (result.size > 0) {
-          debug(s"Found ${result.size} matching name(s): [${result.mkString(", ")}]")
+        val names: Set[String] = parentType.members.filter { symbol =>
+            // filter out values already found by implicitValuesFinder
+            implicitValue.map(_.symbol.pos != symbol.pos).getOrElse(true) &&
+              checkCandidate(symbol.typeSignature)
+          }.map { symbol =>
+            // For (lazy) vals, the names have a space at the end of the name (probably some compiler internals).
+            // Hence the trim.
+            symbol.name.decodedName.toString.trim()
+          }(collection.breakOut)
+        if (names.size > 0) {
+          debug(s"Found ${names.size} matching name(s): [${names.mkString(", ")}]")
         }
-
-        result.toSet
+        names.map(Ident(_))(collection.breakOut)
       }
     }
 
     @tailrec
-    def findInParents(parents: List[Tree], acc: Set[Name]): Set[Name] = {
+    def findInParents(parents: List[Tree], acc: List[Tree]): List[Tree] = {
       parents match {
         case Nil => acc
         case parent :: tail => findInParents(tail, findInParent(parent) ++ acc)
@@ -69,8 +71,6 @@ private[macwire] class ValuesOfTypeInParentsFinder[C <: Context](val c: C, debug
         c.error(c.enclosingPosition, s"Unknown type of enclosing class: ${e.getClass}")
         Nil
     }
-
-    debug("Looking in parents")
-    findInParents(parents, Set()).toList
+    findInParents(parents, List())
   }
 }

--- a/tests/src/test/resources/commonClassesWithImplicitDependencies
+++ b/tests/src/test/resources/commonClassesWithImplicitDependencies
@@ -1,0 +1,2 @@
+case class Dependency()
+case class Service(implicit val dependency: Dependency)

--- a/tests/src/test/resources/explicitDepsNotWiredWithImplicitVals
+++ b/tests/src/test/resources/explicitDepsNotWiredWithImplicitVals
@@ -1,0 +1,10 @@
+#include commonSimpleClasses
+
+implicit val a = new A()
+implicit val b = new B()
+
+object Test  {
+  val c = wire[C]
+}
+
+require(false) // oops! macro didn't fail as expected..

--- a/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromEnclosingModuleScope
+++ b/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromEnclosingModuleScope
@@ -1,0 +1,9 @@
+#include commonSimpleClasses
+
+object ModuleScope {
+  implicit val a = new A()
+  implicit val b = new B()
+  val c = wire[C]
+}
+require(ModuleScope.c.a eq ModuleScope.a)
+require(ModuleScope.c.b eq ModuleScope.b)

--- a/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromMethodScope
+++ b/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromMethodScope
@@ -1,0 +1,14 @@
+#include commonSimpleClasses
+
+object MethodScope {
+  def someMethod(dependency: A)(implicit a: A, b: B) {
+    val c = wire[C]
+    require(c.a eq a)
+    require(c.b eq b)
+  }
+}
+
+implicit val implicitA = new A()
+implicit val implicitB = new B()
+
+MethodScope.someMethod(new A())

--- a/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromParentsScope
+++ b/tests/src/test/resources/explicitDepsWiredWithImplicitValsFromParentsScope
@@ -1,0 +1,13 @@
+#include commonSimpleClasses
+
+trait DependencyProvider {
+  implicit val a = new A()
+  implicit val b = new B()
+}
+
+object ParentsScope extends DependencyProvider {
+  val c = wire[C]
+}
+
+require(ParentsScope.c.a eq ParentsScope.a)
+require(ParentsScope.c.b eq ParentsScope.b)

--- a/tests/src/test/resources/implicitDepsNotWiredWithExplicitAndImplicitValsInEnclosingClassScope
+++ b/tests/src/test/resources/implicitDepsNotWiredWithExplicitAndImplicitValsInEnclosingClassScope
@@ -1,0 +1,10 @@
+#include commonClassesWithImplicitDependencies
+
+implicit val implicitDependency = new Dependency()
+
+object Test {
+  val regularDependency = new Dependency()
+  val service = wire[Service]
+}
+
+require(false) // oops! macro didn't fail as expected..

--- a/tests/src/test/resources/implicitDepsNotWiredWithExplicitAndImplicitValsInParentsScope
+++ b/tests/src/test/resources/implicitDepsNotWiredWithExplicitAndImplicitValsInParentsScope
@@ -1,0 +1,13 @@
+#include commonClassesWithImplicitDependencies
+
+implicit val implicitDependency = new Dependency()
+
+trait DependencyProvider {
+  lazy val regularDependency: Dependency = new Dependency()
+}
+
+object Test extends DependencyProvider {
+  val service = wire[Service]
+}
+
+require(false) // oops! macro didn't fail as expected..

--- a/tests/src/test/resources/implicitDepsNotWiredWithoutAnyValsInScope
+++ b/tests/src/test/resources/implicitDepsNotWiredWithoutAnyValsInScope
@@ -1,0 +1,7 @@
+#include commonClassesWithImplicitDependencies
+
+object Test {
+  val service = wire[Service]
+}
+
+require(false) // oops! macro didn't fail as expected..

--- a/tests/src/test/resources/implicitDepsWiredWithExplicitVals
+++ b/tests/src/test/resources/implicitDepsWiredWithExplicitVals
@@ -1,0 +1,8 @@
+#include commonClassesWithImplicitDependencies
+
+object Test {
+  val regularDependency = new Dependency()
+  val service = wire[Service]
+}
+
+require(Test.service.dependency eq Test.regularDependency)

--- a/tests/src/test/resources/implicitDepsWiredWithExplicitValsFromEnclosingModuleScope
+++ b/tests/src/test/resources/implicitDepsWiredWithExplicitValsFromEnclosingModuleScope
@@ -1,0 +1,7 @@
+#include commonClassesWithImplicitDependencies
+
+object ModuleScope {
+  val moduleExplicitDependency = new Dependency()
+  val service = wire[Service]
+}
+require(ModuleScope.service.dependency eq ModuleScope.moduleExplicitDependency)

--- a/tests/src/test/resources/implicitDepsWiredWithExplicitValsFromParentsScope
+++ b/tests/src/test/resources/implicitDepsWiredWithExplicitValsFromParentsScope
@@ -1,0 +1,11 @@
+#include commonClassesWithImplicitDependencies
+
+trait DependencyProvider {
+  val explicitDependency = new Dependency
+}
+
+object ParentsScope extends DependencyProvider {
+  val service = wire[Service]
+}
+
+require(ParentsScope.service.dependency eq ParentsScope.explicitDependency)

--- a/tests/src/test/resources/implicitDepsWiredWithImplicitVals
+++ b/tests/src/test/resources/implicitDepsWiredWithImplicitVals
@@ -1,0 +1,9 @@
+#include commonClassesWithImplicitDependencies
+
+implicit val dependency = new Dependency
+
+object Test  {
+  val service = wire[Service]
+}
+
+require(Test.service.dependency eq dependency)

--- a/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromEnclosingModuleScope
+++ b/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromEnclosingModuleScope
@@ -1,0 +1,7 @@
+#include commonClassesWithImplicitDependencies
+
+object ModuleScope {
+  implicit val moduleImplicitDependency = new Dependency()
+  val service = wire[Service]
+}
+require(ModuleScope.service.dependency eq ModuleScope.moduleImplicitDependency)

--- a/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromMethodScope
+++ b/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromMethodScope
@@ -1,0 +1,12 @@
+#include commonClassesWithImplicitDependencies
+
+object MethodScope {
+  def someMethod(dependency: Dependency)(implicit implicitDependency: Dependency) {
+    val service = wire[Service]
+    require(service.dependency eq dependency)
+  }
+}
+
+implicit val someImplicit = new Dependency
+
+MethodScope.someMethod(new Dependency)

--- a/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromParentsScope
+++ b/tests/src/test/resources/implicitDepsWiredWithImplicitValsFromParentsScope
@@ -1,0 +1,11 @@
+#include commonClassesWithImplicitDependencies
+
+trait DependencyProvider {
+  implicit val implicitDependency = new Dependency
+}
+
+object ParentsScope extends DependencyProvider {
+  val service = wire[Service]
+}
+
+require(ParentsScope.service.dependency eq ParentsScope.implicitDependency)

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -42,7 +42,26 @@ class CompileTests extends FlatSpec with ShouldMatchers {
     ("wiredInherited", Nil),
     ("wiredDefs", Nil),
     ("wiredFromClass", Nil),
-    ("wiredClassWithTypeParameters", Nil)
+    ("wiredClassWithTypeParameters", Nil),
+    // explicit param should not be resolved with implicit value when dependency cannot be found during plain, old regular lookup
+    ("explicitDepsNotWiredWithImplicitVals", List("Cannot find a value of type", "A")),
+    // non-implicit params should be resolved with implicit values if are in scope
+    ("explicitDepsWiredWithImplicitValsFromMethodScope", Nil),
+    ("explicitDepsWiredWithImplicitValsFromEnclosingModuleScope", Nil),
+    ("explicitDepsWiredWithImplicitValsFromParentsScope", Nil),
+    // implicit params should be resolved with implicit values
+    ("implicitDepsWiredWithImplicitVals", Nil),
+    ("implicitDepsWiredWithImplicitValsFromMethodScope", Nil),
+    ("implicitDepsWiredWithImplicitValsFromEnclosingModuleScope", Nil),
+    ("implicitDepsWiredWithImplicitValsFromParentsScope", Nil),
+    // implicit params should be resolved with regular values
+    ("implicitDepsWiredWithExplicitVals", Nil),
+    ("implicitDepsWiredWithExplicitValsFromEnclosingModuleScope", Nil),
+    ("implicitDepsWiredWithExplicitValsFromParentsScope", Nil),
+    // dependency resolution should abort compilation when there are ambiguous dependencies in scope
+    ("implicitDepsNotWiredWithExplicitAndImplicitValsInEnclosingClassScope", List("Found multiple values of type [Dependency]", "regularDependency", "implicitDependency")),
+    ("implicitDepsNotWiredWithExplicitAndImplicitValsInParentsScope", List("Found multiple values of type [Dependency]", "regularDependency", "implicitDependency")),
+    ("implicitDepsNotWiredWithoutAnyValsInScope", List("Cannot find a value of type", "Dependency"))
   )
 
   for ((testName, expectedErrors) <- tests)


### PR DESCRIPTION
If service takes an implicit argument in its constructor, then wire[T] will also try to infer them using c.inferImplicitValue.
In case when both, explicit and implicit values are found, then compiler error will be raised.

See test cases for more examples.

Implements feature request from issue#17
