### PR TITLE
Resolving multiple values conflict by param name

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/DependencyResolver.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/DependencyResolver.scala
@@ -54,8 +54,16 @@ private[macwire] class DependencyResolver[C <: blackbox.Context](val c: C, debug
           debug(s"Found single value: [$value] of type [$t]")
           Some(value)
         case values =>
-          c.error(c.enclosingPosition, s"Found multiple values of type [$t]: [$values]")
-          None
+          val matching = values.filter {
+            case Ident(sym) => sym == param.name
+          }
+
+          if(matching.size == 1)
+            matching.headOption
+          else {
+            c.error(c.enclosingPosition, s"Found multiple values of type [$t]: [$values]")
+            None
+          }
       }
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -88,6 +88,15 @@ object MacwireBuild extends Build {
       fork in test := true)
   ) dependsOn(macros, runtime)
 
+  lazy val test3: Project = Project(
+    "tests3",
+    file("tests3"),
+    settings = buildSettings ++ Seq(
+      publishArtifact := false,
+      libraryDependencies ++= Seq(scalatest),
+      fork in test := true)
+  ) dependsOn(macros, runtime)
+
   lazy val examplesScalatra: Project = {
     val ScalatraVersion = "2.3.0"
     val scalatraCore = "org.scalatra" %% "scalatra" % ScalatraVersion

--- a/tests3/src/test/scala/foo/bar/FindByVarName.scala
+++ b/tests3/src/test/scala/foo/bar/FindByVarName.scala
@@ -1,0 +1,15 @@
+package foo.bar
+
+import com.softwaremill.macwire.Macwire
+
+object FindByVarName extends Macwire {
+  class Foo
+  class Bar(foo: Foo)
+  class Baz(baz: Foo)
+
+  lazy val foo = wire[Foo]
+  lazy val baz = wire[Foo]
+
+  lazy val bar = wire[Bar]
+  lazy val bar2 = wire[Baz]
+}


### PR DESCRIPTION
You have written `if multiple values are found, a by name-match is attempted` but it does not seem to work. I think that my fix is doing the job or I missunderstood what is in documentation and fix is pointless. Take a look at `Bar` and `Baz` classes. Because they relay on `Foo` class and there are two instances of `Foo` but with different names. Maybe this example is not very accurate but it is missing for me when I've tried to use MacWire with Actors. I had two `ActorRef`s in context but they are different actors. DI couldn't resolve them.
