### PR TITLE
fix wiredInModule visibility bug

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
@@ -96,28 +96,28 @@ object MacwireMacros extends Macwire {
       val pairs = members
         .filter(_.isMethod)
         .flatMap { m =>
-        extractTypeFromNullaryType(m.typeSignature) match {
-          case Some(tpe) => Some((m, tpe))
-          case None =>
-            debug(s"Cannot extract type from ${m.typeSignature} for member $m!")
-            None
+          extractTypeFromNullaryType(m.typeSignature) match {
+            case Some(tpe) => Some((m, tpe))
+            case None =>
+              debug(s"Cannot extract type from ${m.typeSignature} for member $m!")
+              None
+          }
         }
-      }
         .filter { case (_, tpe) => tpe <:< typeOf[AnyRef] }
         .map { case (member, tpe) =>
-        val key = Literal(Constant(tpe))
-        val value = Select(Ident(TermName(capturedInName)), TermName(member.name.decodedName.toString.trim))
+          val key = Literal(Constant(tpe))
+          val value = Select(Ident(TermName(capturedInName)), TermName(member.name.decodedName.toString.trim))
 
-        debug(s"Found a mapping: $key -> $value")
+          debug(s"Found a mapping: $key -> $value")
 
-        // Generating: () => value
-        val valueExpr = c.Expr[AnyRef](value)
-        val createValueExpr = reify { () => valueExpr.splice }
+          // Generating: () => value
+          val valueExpr = c.Expr[AnyRef](value)
+          val createValueExpr = reify { () => valueExpr.splice }
 
-        // Generating: key -> value
-        Apply(Select(Apply(Select(predefIdent, TermName("ArrowAssoc")), List(key)),
-          TermName("$minus$greater")), List(createValueExpr.tree))
-      }
+          // Generating: key -> value
+          Apply(Select(Apply(Select(predefIdent, TermName("ArrowAssoc")), List(key)),
+            TermName("$minus$greater")), List(createValueExpr.tree))
+        }
 
       pairs.toList
     }

--- a/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
@@ -94,7 +94,7 @@ object MacwireMacros extends Macwire {
       val members = tree.tpe.members
 
       val pairs = members
-        .filter(_.isMethod)
+        .filter(s => s.isMethod && s.isPublic)
         .flatMap { m =>
           extractTypeFromNullaryType(m.typeSignature) match {
             case Some(tpe) => Some((m, tpe))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0") 

--- a/tests/src/test/resources/wiredVisibility
+++ b/tests/src/test/resources/wiredVisibility
@@ -1,0 +1,16 @@
+#include commonSimpleClasses
+
+object Test {
+    val theA = new A
+    private val theB = new B
+    protected val theC = wire[C]
+}
+
+val wired = wiredInModule(Test)
+
+// visible
+wired.lookupSingleOrThrow(classOf[A])
+
+// not visible
+require(wired.lookup(classOf[B]) == Nil)
+require(wired.lookup(classOf[C]) == Nil)

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -52,6 +52,7 @@ class CompileTests extends FlatSpec with ShouldMatchers {
     ("wiredInherited", success),
     ("wiredDefs", success),
     ("wiredFromClass", success),
+    ("wiredVisibility", success),
     ("wiredClassWithTypeParameters", success),
     // explicit param should not be resolved with implicit value when dependency cannot be found during plain, old regular lookup
     ("explicitDepsNotWiredWithImplicitVals", compileErr(valueNotFound("A"))),


### PR DESCRIPTION
The following currently does not compile as `wiredInModule` does not take visibility into account.
```scala
object Test {
    val theA = new A
    private val theB = new B
    protected val theC = wire[C]
}

val wired = wiredInModule(Test)
```