### PR TITLE
fix parameterized parent lookup

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ValuesOfTypeInParentsFinder.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/dependencyLookup/ValuesOfTypeInParentsFinder.scala
@@ -27,6 +27,11 @@ private[dependencyLookup] class ValuesOfTypeInParentsFinder[C <: Context](val c:
         val parentType = if (parent.tpe == null) {
           debug("Parent type is null. Creating an expression of parent's type and type-checking that expression ...")
 
+          val tpe = parent match {
+            case q"$tpe(..$params)" => tpe
+            case q"$tpe" =>  tpe
+          }
+
           /*
           It sometimes happens that the parent type is not yet calculated; this seems to be the case if for example
           the parent is in the same compilation unit, but different package.
@@ -37,7 +42,7 @@ private[dependencyLookup] class ValuesOfTypeInParentsFinder[C <: Context](val c:
           In order to construct the tree, we borrow some elements from a reified expression for String. To get the
           desired expression we need to swap the String part with parent.
            */
-          typeCheckUtil.typeCheckExpressionOfType(parent)
+          typeCheckUtil.typeCheckExpressionOfType(tpe)
         } else {
           parent.tpe
         }

--- a/tests/src/test/resources/inheritanceParametrized
+++ b/tests/src/test/resources/inheritanceParametrized
@@ -1,0 +1,13 @@
+#include commonSimpleClasses
+
+class Base(name: String) {
+    lazy val theA = wire[A]
+    lazy val theB = wire[B]
+}
+
+object t extends Base("toto") {
+    lazy val theC = wire[C]
+}
+
+require(t.theC.a eq t.theA)
+require(t.theC.b eq t.theB)

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -37,6 +37,7 @@ class CompileTests extends FlatSpec with ShouldMatchers {
     ("classesWithTraitsLazyValsOkInTrait", success),
     ("inheritanceSimpleLazyValsOkInTraits", success),
     ("inheritanceSimpleDefsOkInTraits", success),
+    ("inheritanceParametrized", success),
     ("inheritanceTwoLevelSimpleLazyValsOkInTraits", success),
     ("inheritanceDoubleSimpleLazyValsOkInTraits", success),
     ("inheritanceClassesWithTraitsLazyValsOkInTraits", success),


### PR DESCRIPTION
The following

    class DependencyProvider(name: String) {
      val explicitDependency = new Dependency
    }

    object ParentsScope extends DependencyProvider("toto") {
      val service = wire[Service]
    }

was breaking as `ValuesOfTypeInParentsFinder` was type checking the tree
`DependencyProvider("toto")` which is not a valid expression.