### PR TITLE
add support to import rename

### DIFF
--- a/tests/src/test/resources/importRename
+++ b/tests/src/test/resources/importRename
@@ -1,0 +1,17 @@
+#include commonSimpleClasses
+
+class Base {
+    lazy val theA = wire[A]
+    lazy val theB = wire[B]
+}
+
+class Main(val base: Base) {
+    import base.{theA => blabla, theB => blibli}
+
+    lazy val theC = wire[C]
+}
+
+val main = new Main(new Base)
+
+require(main.theC.a eq main.base.theA)
+require(main.theC.b eq main.base.theB)

--- a/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
+++ b/tests/src/test/scala/com/softwaremill/macwire/CompileTests.scala
@@ -36,6 +36,7 @@ class CompileTests extends FlatSpec with Matchers {
     ("classesWithTraitsLazyValsOkInTrait", success),
     ("import", success),
     ("importAmbiguous", compileErr(ambiguousResMsg("A"), "myA", "theA")),
+    ("importRename", success),
     ("importWildcard", success),
     ("importWildcardVisibility", success),
     ("inheritanceSimpleLazyValsOkInTraits", success),


### PR DESCRIPTION
Expressions such as `import stuff.{member => renamedMember}` were
not understood by macwire, which was incorrectly using `member` rather
than `renamedMember`.