### PR TITLE
fix implicit parameters detection

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
@@ -33,7 +33,7 @@ object MacwireMacros {
             var newT: Tree = Select(New(Ident(targetTpe.typeSymbol)), termNames.CONSTRUCTOR)
 
             for {
-              targetConstructorParams <- targetConstructorParamLists if !targetConstructorParams.exists(_.isImplicit)
+              targetConstructorParams <- targetConstructorParamLists if !targetConstructorParams.headOption.exists(_.isImplicit)
             } {
               val constructorParams: List[c.Tree] = for (param <- targetConstructorParams) yield {
                 // Resolve type parameters

--- a/tests/src/test/resources/test-cases/valsFlaggedImplicit.success
+++ b/tests/src/test/resources/test-cases/valsFlaggedImplicit.success
@@ -1,0 +1,17 @@
+#include commonSimpleClasses
+
+// b isn't an implicit parameter it is an implicit member
+// this is (to me at least) a shadowy part of the specification
+class Service(val a: A, implicit val b: B)
+
+object Test {
+    lazy val a = wire[A]
+    lazy val b = wire[B]
+
+    // if macwire let the compiler wire the dependencies it will fail
+    // as `a` isn't implicit
+    lazy val service = wire[Service]
+}
+
+require(Test.service.a eq Test.a)
+require(Test.service.b eq Test.b)


### PR DESCRIPTION
This is not an implicit parameter:
```
class Service(val a: A, implicit val b: B)
```