### PR TITLE
do not ignore imported implicit members

### DIFF
--- a/tests/src/test/resources/test-cases/importImplicit.success
+++ b/tests/src/test/resources/test-cases/importImplicit.success
@@ -1,0 +1,14 @@
+case class A()
+case class B(a: A)
+
+object Import {
+    implicit val a = A()
+}
+
+object Test {
+    import Import.a
+
+    lazy val b: B = wire[B]
+}
+
+require(Test.b.a eq Import.a)


### PR DESCRIPTION
This was a left over from the initial wire from import implementation.