### PR TITLE
configuring logging on app loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,10 @@ import com.softwaremill.macwire._
 
 class AppApplicationLoader extends ApplicationLoader {
   def load(context: Context) = {
+    
+    // make sure logging is configured
+    Logger.configure(context.environment)
+
     (new BuiltInComponentsFromContext(context) with AppComponents).application
   }
 }

--- a/examples/play24/app/com/softwaremill/play24/AppApplicationLoader.scala
+++ b/examples/play24/app/com/softwaremill/play24/AppApplicationLoader.scala
@@ -14,6 +14,10 @@ import scala.concurrent.ExecutionContext
 
 class AppApplicationLoader extends ApplicationLoader {
   def load(context: Context) = {
+
+    // make sure logging is configured
+    Logger.configure(context.environment)
+
     (new BuiltInComponentsFromContext(context) with AppComponents).application
   }
 }


### PR DESCRIPTION
Logging won't be configured without calling it explicitly. 
The default Play will do it automatically, but if we define a customer loader we'll have no logging at all unless we call:
```scala
Logger.configure(context.environment)
```

