### PR TITLE
Allow to wire shapeless HList with wireHList[A] method

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/HListWrapper.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/HListWrapper.scala
@@ -1,0 +1,6 @@
+package com.softwaremill.macwire
+
+import shapeless._
+
+final case class HListWrapper[T] (list: HList) {
+}

--- a/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/MacwireMacros.scala
@@ -3,6 +3,7 @@ package com.softwaremill.macwire
 import com.softwaremill.macwire.dependencyLookup._
 
 import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 
 object MacwireMacros {
   private val log = new Logger()
@@ -137,6 +138,22 @@ object MacwireMacros {
     // The lack of hygiene can be seen here as a feature, the choice of Set implementation
     // is left to the user - you want a `mutable.Set`, just import `mutable.Set` before the `wireSet[T]` call
     val code = q"Set(..$instances)"
+
+    log("Generated code: " + show(code))
+    code
+  }
+
+  def wireHList_impl[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    val targetType = implicitly[c.WeakTypeTag[T]]
+
+    val dependencyResolver = new DependencyResolver[c.type](c, log)
+
+    val instances = dependencyResolver.resolveAll(targetType.tpe)
+
+    val l = instances.foldRight(q"HNil": Tree)((a, b) => q"$a::$b")
+    val code = q"import shapeless._; HListWrapper[${targetType.tpe}]($l)"
 
     log("Generated code: " + show(code))
     code

--- a/macros/src/main/scala/com/softwaremill/macwire/package.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/package.scala
@@ -1,11 +1,14 @@
 package com.softwaremill
 
 import scala.language.experimental.macros
+import shapeless._
 
 package object macwire {
   def wire[T]: T = macro MacwireMacros.wire_impl[T]
 
   def wireSet[T]: Set[T] = macro MacwireMacros.wireSet_impl[T]
+
+  def wireHList[T]: HListWrapper[T] = macro MacwireMacros.wireHList_impl[T]
 
   def wireWith[A,RES](factory: (A) => RES): RES = macro MacwireMacros.wireWith_impl[RES]
   def wireWith[A,B,RES](factory: (A,B) => RES): RES = macro MacwireMacros.wireWith_impl[RES]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -69,7 +69,11 @@ object MacwireBuild extends Build {
   lazy val macros = project.in(file("macros")).
     settings(commonSettings).
     settings(
-      libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value).
+      libraryDependencies ++= Seq(
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "com.chuusai" %% "shapeless" % "2.2.5"
+      )
+    ).
     dependsOn(util % "provided")
 
   lazy val proxy = project.in(file("proxy")).

--- a/tests/src/test/resources/test-cases/wireHList.success
+++ b/tests/src/test/resources/test-cases/wireHList.success
@@ -26,13 +26,13 @@ class App(plugin1: Plugin1, plugin2: Plugin2) extends Module3 {
 
     lazy val a4: A = wire[A4]
 
-    // wireSet look at the usual places:
+    // wireHList look at the usual places:
     // - enclosing members
     // - enclosing imports
     // - parents
     lazy val as : HListWrapper[A] = wireHList[A]
 
-    // inject that Set of A into Group
+    // inject that HListWrapper of A into Group
     lazy val group: Group = wire[Group]
 }
 

--- a/tests/src/test/resources/test-cases/wireHList.success
+++ b/tests/src/test/resources/test-cases/wireHList.success
@@ -1,0 +1,44 @@
+import shapeless._
+
+trait A
+class A1 extends A
+class A2 extends A
+class A3 extends A
+class A4 extends A
+
+case class Group(as: HListWrapper[A])
+
+class Plugin1 {
+    lazy val a1: A = wire[A1]
+}
+
+class Plugin2 {
+    lazy val a2: A = wire[A2]
+}
+
+trait Module3 {
+    lazy val a3: A = wire[A3]
+}
+
+class App(plugin1: Plugin1, plugin2: Plugin2) extends Module3 {
+    import plugin1._
+    import plugin2._
+
+    lazy val a4: A = wire[A4]
+
+    // wireSet look at the usual places:
+    // - enclosing members
+    // - enclosing imports
+    // - parents
+    lazy val as : HListWrapper[A] = wireHList[A]
+
+    // inject that Set of A into Group
+    lazy val group: Group = wire[Group]
+}
+
+val plugin1 = new Plugin1
+val plugin2 = new Plugin2
+val app = new App(plugin1, plugin2)
+
+
+require(app.group.as == HListWrapper[A](plugin1.a1 :: plugin2.a2 :: app.a4 :: app.a3 :: HNil))


### PR DESCRIPTION
The main purpose of this pull request is to allow to wire shapeless HList with wireHList[A] method like it already can be done for ordinary Sets with wireSet[A]. The result of this operation will be HListWrapper[A]. All this stuff allows to inject plugin-like entities in a type safe manner without loosing plugins exact types and without generalizing them to the specified base class\trait.

Two main consequences:
1. Shapeless library need to be added to the list of dependencies
2. wireHList[A] macro implementation make use of the whitebox environment in order to be able to vary return type based on the plugins in scope.

You can see the example here, in the appropriate [test file](https://github.com/numesmat/macwire/blob/wire_hlist/tests/src/test/resources/test-cases/wireHList.success)
