### PR TITLE
A small discrepancy in Play readme part

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ class AppApplicationLoader extends ApplicationLoader {
 trait AppComponents extends BuiltInComponents with AppModule {
   lazy val assets: Assets = wire[Assets]
   lazy val prefix: String = "/"
-  lazy val router: Router = wire[Routes]
+  lazy val routes: Routes = wire[Routes]
 }
 
 trait AppModule {


### PR DESCRIPTION
Having `lazy val route: Route = wire[Routes]` causes a type mismatch. I think you did mean having `lazy val routes: Routes = wire[Routes]` in here.