### PR TITLE
fixed #103

### DIFF
--- a/tests/src/test/resources/test-cases/t103.success
+++ b/tests/src/test/resources/test-cases/t103.success
@@ -1,0 +1,12 @@
+class Test1(val s: Set[String])
+
+val set1: Set[String] = Set()
+val t1 = wire[Test1]
+
+require(t1.s eq Set[String]())
+
+class Test2(val list: List[String])
+val list2 = List[String]()
+val t2 = wire[Test2]
+
+require(t2.list eq List[String]())


### PR DESCRIPTION
I think there might be a better way, but currently this works and may be accepted based on the least power principle, I hope.

The problem was that in case of a `val set: Set[String] = Set()`, the typecheck was performed on the `Set()` tree, which resulted in a `Set[Nothing]`, hence lookup failure.

Straightforward checks of the left-hand side's `tpt` failed some tests though, so I wound up with this solution. In case it won't satisfy some criteria, I hope it at least provides insight on where to dig from further.