### PR TITLE
Do not ignore Actors' implicit parameters

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/internals/ConstructorCrimper.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/internals/ConstructorCrimper.scala
@@ -55,7 +55,7 @@ private[macwire] class ConstructorCrimper[C <: blackbox.Context, T: C#WeakTypeTa
 
   def wireConstructorParams(paramLists: List[List[Symbol]]): List[List[Tree]] = paramLists.map(_.map(p => dependencyResolver.resolve(p, /*SI-4751*/paramType(p))))
 
-  private def paramType(param: Symbol): Type = {
+  private[macwire] def paramType(param: Symbol): Type = {
     val (sym: Symbol, tpeArgs: List[Type]) = targetTypeD match {
       case TypeRef(_, sym, tpeArgs) => (sym, tpeArgs)
       case t => abort(s"Target type not supported for wiring: $t. Please file a bug report with your use-case.")

--- a/macrosAkka/src/main/scala/com/softwaremill/macwire/akkasupport/internals/Crimper.scala
+++ b/macrosAkka/src/main/scala/com/softwaremill/macwire/akkasupport/internals/Crimper.scala
@@ -12,9 +12,14 @@ private[macwire] final class Crimper[C <: blackbox.Context, T: C#WeakTypeTag](va
 
   lazy val targetType: Type = cc.targetType
 
-  lazy val args: List[Tree] = cc.constructorArgs
+  lazy val args: List[Tree] = cc.constructor.map(_.asMethod.paramLists).map(wireConstructorParams)
     .getOrElse(c.abort(c.enclosingPosition, s"Cannot find a public constructor for [$targetType]"))
     .flatten
+
+  def wireConstructorParams(paramLists: List[List[Symbol]]): List[List[Tree]] = paramLists.map(_.map {
+    case i if i.isImplicit => q"implicitly[${cc.paramType(i)}]"
+    case p => cc.dependencyResolver.resolve(p, /*SI-4751*/cc.paramType(p))
+  })
 
   lazy val propsTree = q"akka.actor.Props(classOf[$targetType], ..$args)"
 

--- a/macrosAkkaTests/src/test/resources/test-cases/wireActor-13-missingImplicitDependency.failure
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireActor-13-missingImplicitDependency.failure
@@ -1,0 +1,30 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireActor-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireActor-14-implicitParameters.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireActor-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireActor-15-injectAnnotationImplicit.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireActor-15-injectAnnotationImplicit.success
@@ -1,0 +1,41 @@
+import akka.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireActor[SomeActor]("bob")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-13-missingImplicitDependency.failure
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-13-missingImplicitDependency.failure
@@ -1,0 +1,30 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-14-implicitParameters.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-14-implicitParameters.success
@@ -1,0 +1,30 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireAnonymousActor-14-implicitParameters")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-15-injectAnnotationImplicit.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireAnonymousActor-15-injectAnnotationImplicit.success
@@ -1,0 +1,41 @@
+import akka.actor.{Actor, ActorSystem}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val someActor = wireAnonymousActor[SomeActor]
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireProps-13-missingImplicitDependency.failure
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireProps-13-missingImplicitDependency.failure
@@ -1,0 +1,32 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+val d = new D {}
+
+val system = ActorSystem("wireProps-13-missingImplicitDependency")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireProps-14-implicitParameters.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireProps-14-implicitParameters.success
@@ -1,0 +1,32 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am constructing simple actor with many parameter lists and an implicit parameter list.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A)(b: B, c: C)(implicit d: D)  extends Actor {
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+val a = new A {}
+val b = new B {}
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireProps-14-implicitParameters")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/resources/test-cases/wireProps-15-injectAnnotationImplicit.success
+++ b/macrosAkkaTests/src/test/resources/test-cases/wireProps-15-injectAnnotationImplicit.success
@@ -1,0 +1,43 @@
+import akka.actor.{Actor, ActorSystem, Props}
+import com.softwaremill.macwire.akkasupport._
+
+/**
+  * In this example I am creating actor that has 3 constructors.
+  * However `wire*` will find dependencies for the constructor annotated
+  * with @Inject and provide it's arguments to Props factory method.
+  */
+
+trait A
+trait B
+trait C
+trait D
+
+class SomeActor(a: A, d: D) extends Actor {
+
+  def this(b: B) = {
+    this(new A{}, new D{})
+    throw new UnsupportedOperationException()
+  }
+
+  @javax.inject.Inject
+  def this(c: C)(implicit d: D) = this(new A{}, d)
+
+  override def receive: Receive = {
+    case m => //println(m)
+  }
+}
+
+lazy val a: A = throw new UnsupportedOperationException()
+lazy val b: B = throw new UnsupportedOperationException()
+val c = new C {}
+implicit val d = new D {}
+
+val system = ActorSystem("wireActor-15-injectAnnotation")
+AfterAllTerminate(system)
+
+val props: Props = wireProps[SomeActor]
+
+val someActor = system.actorOf(props, "someActor")
+
+someActor ! "Hey someActor"
+

--- a/macrosAkkaTests/src/test/scala/com/softwaremill/macwire/akkasupport/CompileTests.scala
+++ b/macrosAkkaTests/src/test/scala/com/softwaremill/macwire/akkasupport/CompileTests.scala
@@ -22,7 +22,10 @@ class CompileTests extends CompileTestsSupport {
       "wireActor-11-toManyInjectAnnotations" -> List("Ambiguous constructors annotated with @javax.inject.Inject for type [SomeActor]"),
       "wireProps-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
       "wireAnonymousActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
-      "wireActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]")
+      "wireActor-12-noPublicConstructor" -> List("Cannot find a public constructor for [SomeActor]"),
+      "wireActor-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireAnonymousActor-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D"),
+      "wireProps-13-missingImplicitDependency" -> List("could not find implicit value for parameter e: D")
     ),
     expectedWarnings = List()
   )


### PR DESCRIPTION
Fix for https://github.com/adamw/macwire/issues/121

I wanted to make it work first, and it works. Please review and let me know if the visibility changes is ok or if code should be copied...

What it does is that given: `class A(b: B)(implicit c: C) extends Actor {`, it wires `wireProps[A]` as: `Props(classOf[A], wiredBInstance, implicitly[C])`. This doesn't interfere with the usual implicit resolution as it let's the compiler find the needed instances implicitly.