### PR TITLE
fix deprecation warning in project/Build.scala

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,9 +9,9 @@ object BuildSettings {
     scalaVersion  := "2.11.11",
     crossScalaVersions := Seq("2.12.3", scalaVersion.value),
     // Sonatype OSS deployment
-    publishTo <<= version { (v: String) =>
+    publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT"))
+      if (version.value.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")


### PR DESCRIPTION
```
[warn] /home/travis/build/adamw/macwire/project/Build.scala:12: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
[warn] See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]     publishTo <<= version { (v: String) =>
[warn]               ^
```