### PR TITLE
Issue 126 - Fixed Bug - Resolve type parameters when inspecting parent traits

### DIFF
--- a/macros/src/main/scala/com/softwaremill/macwire/internals/EligibleValuesFinder.scala
+++ b/macros/src/main/scala/com/softwaremill/macwire/internals/EligibleValuesFinder.scala
@@ -131,6 +131,10 @@ private[macwire] class EligibleValuesFinder[C <: blackbox.Context](val c: C, log
           case ident : Ident => List(ident)
           case CompoundTypeTree(Template(selfParents,_,_)) => selfParents
           case x : Select if x.isType => List(x)
+
+          // Self types with type parameters
+          case ta : AppliedTypeTree => List(ta)
+
           case _ => Nil
         }
         pp ++ selfTypes
@@ -160,7 +164,7 @@ private[macwire] class EligibleValuesFinder[C <: blackbox.Context](val c: C, log
             // Get a view of this symbol as seen from the enclosing class
             // This ensures that type parameters are resolved correctly in parent traits.
             // See - https://github.com/adamw/macwire/issues/126
-            val found = symbol.typeSignature.asSeenFrom(root, tpe.symbol)
+            val found = symbol.typeSignatureIn( root )
 
             newValues.put(Scope.ParentOrModule, found,
               Ident(TermName(symbol.name.decodedName.toString.trim()))) // q"$symbol" crashes the compiler...

--- a/test-util/src/main/resources/include/commonHKTClasses
+++ b/test-util/src/main/resources/include/commonHKTClasses
@@ -1,0 +1,8 @@
+import scala.language.higherKinds
+
+case class A[FA[_]]()
+case class B[FB[_]]( a:A[FB] )
+case class C[FC[_]]( a:A[FC], b:B[FC] )
+
+trait IO[T]
+trait OptionT[F[_], T]

--- a/tests/src/test/resources/test-cases/inheritanceHKT.success
+++ b/tests/src/test/resources/test-cases/inheritanceHKT.success
@@ -1,0 +1,19 @@
+#include commonHKTClasses
+
+trait Base1[F[_]] {
+  lazy val a = wire[A[F]]
+}
+
+trait Child1[F[_]] extends Base1[F] {
+  lazy val b = wire[B[F]]
+}
+
+trait Child2[F[_]] extends Base1[F] with Child1[F] {
+  lazy val c = wire[C[F]]
+}
+
+object ChildIO extends Child2[IO]
+
+require(ChildIO.b.a == ChildIO.a)
+require(ChildIO.c.a == ChildIO.a)
+require(ChildIO.c.b == ChildIO.b)

--- a/tests/src/test/resources/test-cases/selfTypeHKT.success
+++ b/tests/src/test/resources/test-cases/selfTypeHKT.success
@@ -1,0 +1,51 @@
+#include commonHKTClasses
+
+trait AProvider[APF[_]] {
+    def a : A[APF]
+}
+
+trait BProvider[BPF[_]] {
+    def b : B[BPF]
+}
+
+trait ModuleSimple[MSF[_]] { this : AProvider[MSF] =>
+    lazy val b = wire[B[MSF]]
+    lazy val c = wire[C[MSF]]
+}
+
+trait ModuleMultiple[MMF[_]] { this : AProvider[MMF] with BProvider[MMF] =>
+    lazy val c = wire[C[MMF]]
+}
+
+trait AProviderImpl[AIF[_]] extends AProvider[AIF] {
+    lazy val a = wire[A[AIF]]
+}
+
+trait ABProviderImpl[ABIF[_]] extends AProvider[ABIF] with BProvider[ABIF] {
+    lazy val a = wire[A[ABIF]]
+    lazy val b = wire[B[ABIF]]
+}
+
+object TestSimple extends ModuleSimple[IO] with AProviderImpl[IO]
+
+require(TestSimple.c.a == TestSimple.a)
+require(TestSimple.c.b == TestSimple.b)
+
+
+object TestMultiple extends ModuleMultiple[IO] with ABProviderImpl[IO]
+
+require(TestMultiple.c.a == TestMultiple.a)
+require(TestMultiple.c.b == TestMultiple.b)
+
+
+object ProviderAliasing {
+  type AAndB[AABF[_]] = AProvider[AABF] with BProvider[AABF]
+}
+
+trait AliasedMultiModule[AMMF[_]] { this: ProviderAliasing.AAndB[AMMF] =>
+  lazy val c = wire[C[AMMF]]
+}
+
+object TestAliasedMultiple extends AliasedMultiModule[IO] with ABProviderImpl[IO]
+require(TestAliasedMultiple.c.a == TestAliasedMultiple.a)
+require(TestAliasedMultiple.c.b == TestAliasedMultiple.b)


### PR DESCRIPTION
This resolves https://github.com/adamw/macwire/issues/126 